### PR TITLE
Add logic for ignoring any extra yaml fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /out/
+venv

--- a/calendars/_config.yaml
+++ b/calendars/_config.yaml
@@ -4,3 +4,5 @@ description: |
   calendars/_config.yaml <b>HTML bold</b>.  *Markdown italic.*
 
   Second paragraph.
+event_url: wooasd
+magic: abrakadabra

--- a/git_calendar/build.py
+++ b/git_calendar/build.py
@@ -12,7 +12,7 @@ import jinja2
 import markdown_it
 import yaml
 
-import yaml2ics
+from . import yaml2ics
 
 TEMPLATE_DIR = Path(__file__).parent/'templates'
 

--- a/git_calendar/yaml2ics.py
+++ b/git_calendar/yaml2ics.py
@@ -30,7 +30,7 @@ interval_type = {
 }
 
 EVENT_FIELDS = (
-    "name", 
+    "summary", 
     "begin", 
     "end", 
     "duration",

--- a/git_calendar/yaml2ics.py
+++ b/git_calendar/yaml2ics.py
@@ -62,7 +62,7 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
         d[key] = d[key].strip() if isinstance(d[key], str) else d[key]
 
 
-    d = dict((k, d[k]) for k in EVENT_FIELDS)
+    d = {k: d[k] for k in d.keys() & EVENT_FIELDS}
 
     # See https://icspy.readthedocs.io/en/stable/api.html#event
     #

--- a/git_calendar/yaml2ics.py
+++ b/git_calendar/yaml2ics.py
@@ -29,6 +29,27 @@ interval_type = {
     "years": dateutil.rrule.YEARLY,
 }
 
+EVENT_FIELDS = (
+    "name", 
+    "begin", 
+    "end", 
+    "duration",
+    "uid", 
+    "description", 
+    "created", 
+    "last_modified",
+    "location", 
+    "url", 
+    "transparent", 
+    "alarms", 
+    "attendees", 
+    "categories", 
+    "status",
+    "organizer",
+    "geo", 
+    "classification"
+)
+
 
 def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
     d = event_yaml
@@ -39,6 +60,9 @@ def event_from_yaml(event_yaml: dict, tz: tzinfo = None) -> ics.Event:
     # Strip all string values, since they often end on `\n`
     for key in d:
         d[key] = d[key].strip() if isinstance(d[key], str) else d[key]
+
+
+    d = dict((k, d[k]) for k in EVENT_FIELDS)
 
     # See https://icspy.readthedocs.io/en/stable/api.html#event
     #


### PR DESCRIPTION
This PR introduces logic for ignoring any extra yaml fields in an event in the data file when creating events with the pyics library. It also reverts to using the local yaml2ics.py file rather than the library.